### PR TITLE
Specify scheme in library.properties url value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=Jeferson Lima <jefersonlimaa@dcc.ufba.br>
 sentence=A library that makes, easier work with Midea Air Conditioners.
 paragraph=Midea is a famous trademark of Air Conditioners, arround the world. This library intend to make it easier, for everyone control this air conditioner, using IRremote library as background.
 category=Communication
-url=jefersonla.github.io
+url=http://jefersonla.github.io/
 architectures=avr


### PR DESCRIPTION
The library.properties url property is used by the Arduino IDE to add a clickable "More info" link to the Library Manager entry for each library. The scheme must be specified in order for this link to be clickable.